### PR TITLE
Import metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,18 +154,18 @@ Your product will be named by concatenating all the directories names. As seen a
 "iats:xenial:amd64:default"
 
 Your product definition, inside images.json file will have these fields:
-- arch = the new of the architecture directory
-- os = the environment|product name
-- release = the release directory name
-- release_title = the release directory name
-- aliases: a single alias with the name of the product.
+- arch = the name of the architecture directory (amd64, in the example)
+- os = the environment|product name (iats, in the example)
+- release = the release directory name (xenial, in the example)
+- release_title = the release directory name (xenial, in the example)
+- aliases: a **single** alias with the name of the product (iats:xenial:amd64:default, in the example)
 
-You can enhance these values by uploading also a 'metadata.json' file (which will not appear in the images.json file), 
+You can change these values by uploading also a 'metadata.json' file (which will not appear in the images.json file), 
 and which can contain the following fields:
 - os
 - release_title
-- aliases = string of aliases, joined by ','. Name of product will be added automatically.
-
+- aliases = string of aliases, joined by ','. Name of product alias will be added automatically.
+Preferably you should upload this 'metadata.json' at the beginning rather than after the big actual image files.
 
 The command `lxd-image-server` can be used to manage the server manually:
 

--- a/lxd_image_server/cli.py
+++ b/lxd_image_server/cli.py
@@ -232,7 +232,7 @@ def init(ctx, root_dir, ssl_dir, ssl_skip, nginx_skip):
 def watch(ctx, img_dir, streams_dir, skip_watch_config_non_existent: bool):
     path_img_dir = str(Path(img_dir).expanduser().resolve())
     path_streams_dir = str(Path(streams_dir).expanduser().resolve())
-    logger.info("lxd-image-server: Starting watch process")
+    logger.info("Starting watch process")
 
     Config.load_data()
     # Lauch threads

--- a/lxd_image_server/cli.py
+++ b/lxd_image_server/cli.py
@@ -60,14 +60,52 @@ def needs_update(events):
     return modified_files
 
 
+
+def config_inotify_setup() -> inotify.adapters.Inotify:
+    i = inotify.adapters.Inotify()
+    watchedDirs = {}
+
+    for p in Config.paths:
+        if os.path.exists(p):
+            if os.path.isfile(p):
+                logger.debug("Watching existing config file {}".format(p))
+                i.add_watch(p, mask= inotify.constants.IN_CLOSE_WRITE | inotify.constants.IN_DELETE)
+            else:
+                logger.debug("Watching existing config directory {}".format(p))
+                i.add_watch(p) # SEEME: all events?
+        else:
+            (d, n) = os.path.split(p)
+            while not os.path.exists(d):
+                (d, n) = os.path.split(d)
+            if d not in watchedDirs:
+                i.add_watch(d, inotify.constants.IN_DELETE | inotify.constants.IN_CLOSE_WRITE | inotify.constants.IN_CREATE)
+                logger.debug("Watching directory {} as base for {}".format(d, p))
+                watchedDirs[d] = True
+
+    return i
+
 @threaded
 def update_config():
-    i = inotify.adapters.Inotify()
-    i.add_watch(Config.path, mask=IN_CLOSE_WRITE)
-    for _ in i.event_gen(yield_nones=False):
-        Config.data = {}
-        Config.load_data()
-        MirrorManager.update_mirror_list()
+    i = config_inotify_setup()
+    while True:
+        reload = False
+        for event in i.event_gen(yield_nones=False):
+            (_, mask, dir, file) = event
+            fp = os.path.join(dir, file).rstrip(os.path.sep)
+            for p in Config.paths:
+                if p == fp or (dir == p):
+                    reload = True
+                    break
+            if reload:
+                break
+
+        if reload:
+            logger.debug("Will reload configuration")
+            Config.reload_data()
+            i = config_inotify_setup()
+            MirrorManager.update_mirror_list()
+        else:
+            logger.debug("No need to reload configuration")
 
 
 @threaded
@@ -80,7 +118,7 @@ def update_metadata(img_dir, streams_dir):
         if ops:
             logger.info('Updating server: %s', ','.join(
                 str(x) for x in ops.ops))
-            images = Images(str(Path(streams_dir).resolve()))
+            images = Images(str(Path(streams_dir).resolve()), logger=logger)
             images.update(ops.ops)
             images.save()
             MirrorManager.update()
@@ -119,7 +157,10 @@ def cli(log_file, verbose):
 def update(ctx, img_dir, streams_dir):
     logger.info('Updating server')
 
-    images = Images(str(Path(streams_dir).resolve()), rebuild=True)
+    img_dir = Path(img_dir).expanduser().resolve()
+    streams_dir = Path(streams_dir).expanduser().resolve()
+
+    images = Images(str(Path(streams_dir).resolve()), rebuild=True, logger=logger)
 
     # Generate a fake event to update all tree
     fake_events = [
@@ -138,16 +179,24 @@ def update(ctx, img_dir, streams_dir):
               show_default=True)
 @click.option('--ssl_dir', default='/etc/nginx/ssl', show_default=True,
               callback=lambda ctx, param, val: Path(val))
+@click.option('--ssl_skip', default=False, is_flag=True)
+@click.option('--nginx_skip', default=False, is_flag=True)
 @click.pass_context
-def init(ctx, root_dir, ssl_dir):
+def init(ctx, root_dir, ssl_dir, ssl_skip, nginx_skip):
+    root_dir = Path(root_dir).expanduser().resolve()
+
     if not Path(root_dir).exists():
         logger.error('Root directory does not exists')
     else:
-        if not ssl_dir.exists():
-            os.makedirs(str(ssl_dir))
+        if nginx_skip:
+            ssl_skip = True
 
-        if not (ssl_dir / 'nginx.key').exists():
-            generate_cert(str(ssl_dir))
+        if not ssl_skip:
+            if not ssl_dir.exists():
+                os.makedirs(str(ssl_dir))
+
+            if not (ssl_dir / 'nginx.key').exists():
+                generate_cert(str(ssl_dir))
 
         img_dir = str(Path(root_dir, 'images'))
         streams_dir = str(Path(root_dir, 'streams/v1'))
@@ -155,11 +204,13 @@ def init(ctx, root_dir, ssl_dir):
             os.makedirs(img_dir)
         if not Path(streams_dir).exists():
             os.makedirs(streams_dir)
-        conf_path = Path('/etc/nginx/sites-enabled/simplestreams.conf')
-        if not conf_path.exists():
-            conf_path.symlink_to(
-                '/etc/nginx/sites-available/simplestreams.conf')
-            os.system('nginx -s reload')
+
+        if not nginx_skip:
+            conf_path = Path('/etc/nginx/sites-enabled/simplestreams.conf')
+            if not conf_path.exists():
+                conf_path.symlink_to(
+                    '/etc/nginx/sites-available/simplestreams.conf')
+                os.system('nginx -s reload')
 
         if not Path(root_dir, 'streams', 'v1', 'images.json').exists():
             ctx.invoke(update, img_dir=Path(root_dir, 'images'),
@@ -179,12 +230,20 @@ def init(ctx, root_dir, ssl_dir):
                               resolve_path=True), show_default=True)
 @click.pass_context
 def watch(ctx, img_dir, streams_dir):
+    path_img_dir = str(Path(img_dir).expanduser().resolve())
+    path_streams_dir = str(Path(streams_dir).expanduser().resolve())
+
     Config.load_data()
     # Lauch threads
+    # SEEME: in case an event will come from watching config files, there is a race condition between update_config
+    # thread using indirectly MirrorManager.img_dir and thread update_metadata setting MirrorManager.img_dir
+    # Also, race condition on calling MirrorManager.update_mirror_list() in both threads.
     update_config()
-    update_metadata(img_dir, streams_dir)
+    update_metadata(path_img_dir, path_streams_dir)
 
-    i = inotify.adapters.InotifyTree(str(Path(img_dir).resolve()),
+    logger.debug("Watching image directory {}".format(path_img_dir))
+
+    i = inotify.adapters.InotifyTree(path_img_dir,
                                      mask=(IN_ATTRIB | IN_DELETE |
                                            IN_MOVED_FROM | IN_MOVED_TO |
                                            IN_CLOSE_WRITE))

--- a/lxd_image_server/simplestreams/images.py
+++ b/lxd_image_server/simplestreams/images.py
@@ -50,16 +50,17 @@ class Version(object):
             sha_object2 = None
             lxd_key_additional = None
 
-            if data['ftype'] in ['squashfs', 'root.tar.xz']:
+            if data['ftype'] in ['squashfs', 'root.tar.xz'] and sha256_lxd is not None:
                 sha_object2 = sha256_lxd.copy()
 
             self._do_sha256_checksum(str(f), [sha_object, sha_object2]),
             data['sha256'] = sha_object.hexdigest()
-            if data['ftype'] == 'squashfs':
-                items[lxd_key]['combined_squashfs_sha256'] = sha_object2.hexdigest()
-            elif data['ftype'] == 'root.tar.xz':
-                # combined_sha256 is legacy key
-                items[lxd_key]['combined_rootxz_sha256'] = items[lxd_key]['combined_sha256'] = sha_object2.hexdigest()
+            if sha_object2 is not None:
+                if data['ftype'] == 'squashfs':
+                    items[lxd_key]['combined_squashfs_sha256'] = sha_object2.hexdigest()
+                elif data['ftype'] == 'root.tar.xz':
+                    # combined_sha256 is legacy key
+                    items[lxd_key]['combined_rootxz_sha256'] = items[lxd_key]['combined_sha256'] = sha_object2.hexdigest()
 
         for (f, data) in items.items():
             self.root[self.name]['items'].update({ Path(f).name : data })

--- a/lxd_image_server/tools/config.py
+++ b/lxd_image_server/tools/config.py
@@ -43,3 +43,8 @@ class Config():
 
         cls.paths = cls.pathsAsDict.keys()
         cls.pathsAsDict = {}
+        # allow lack of any config file
+        if 'mirrors' not in cls.data:
+            cls.data['mirrors'] = {}
+
+

--- a/lxd_image_server/tools/config.py
+++ b/lxd_image_server/tools/config.py
@@ -1,12 +1,45 @@
 import confight
-
+from pathlib import Path
 
 class Config():
 
     data = {}
+    # where the configs are loaded from.
+    paths = []
+
+    # temporary object
+    pathsAsDict = {}
+
+    @classmethod
+    def reload_data(cls):
+        cls.data = {}
+        cls.path = []
+        cls.pathsAsDict = {}
+        cls.load_data()
+
+    original_load_paths = None
+
+    @classmethod
+    def confight_load_paths(cls, paths, finder=None, extension=None,
+                   force_extension=False, **kwargs):
+        for p in paths:
+            p = str(Path(p).expanduser().resolve())
+            cls.pathsAsDict[p] = True
+
+        return cls.original_load_paths(paths, finder, extension, force_extension, **kwargs)
 
     @classmethod
     def load_data(cls):
         if cls.data:
             return
+        cls.original_load_paths = confight.__dict__['load_paths']
+        confight.__dict__['load_paths'] = cls.confight_load_paths
+
         cls.data.update(confight.load_app('lxd-image-server'))
+        # allow non root installs as well
+        cls.data.update(confight.load_user_app('lxd-image-server'))
+
+        confight.__dict__['load_paths'] = cls.original_load_paths
+
+        cls.paths = cls.pathsAsDict.keys()
+        cls.pathsAsDict = {}


### PR DESCRIPTION
Bugfixes:
- #5 - fix calculating checksums
- #4 - fix for field 'path' not present
- fixes the fact that config file(s) could be loaded from multiple places but monitoring not happening for all those places (not happening at all, actually, due to #4)

Features added:
- it is based on the #2 change - so it contains it
- logging: added a prefix, so that inside a docker image where at least nginx is running, you can distinguish message sources
 - I think I added a note about some possible race condition on those 2 threads
- allow to not run nginx and ssl init steps. Think having it running behind a SSL terminating proxy
(kubernetes with cert-manager for example)
- allow multiple aliases and different OS to be specified, by uploading also a 'metadata.json' file.
- updated README.md 