### PR TITLE
add remote config to replace url

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ The configuration file would be:
 [mirrors]
   [mirror1]
   user = "lxdadm"
-  url = "https://mirror1.xxxxxxx.com:8443"
+  remote = "mirror1.xxxxxxx.com"
   key_path = "/etc/lxd-image-server/lxdhub.key"
   [mirror2]
   user = "lxdadm"
-  url = "https://mirror2.xxxxxxx.com:8443"
+  remote = "mirror2.xxxxxxx.com"
   key_path = "/etc/lxd-image-server/lxdhub.key"
 ```
 

--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,8 @@
   # [lxdhub]
   # user = "lxdadm"
   # url = "https://lxdhub.xxxxxxx.com:8443"
+  # remote is replacing url, but url is not removed for backward compatibility
+  # remote = "lxdhub.xxxxxxx.com"
   # Make sure key has 700 permission and the ownership is lxdadm:www-data
   # key_path = "/etc/lxd-image-server/lxdhub.key"
 

--- a/lxd_image_server/tools/mirror.py
+++ b/lxd_image_server/tools/mirror.py
@@ -16,6 +16,7 @@ class Mirror():
     user = attr.ib()
     key_path = attr.ib()
     url = attr.ib()
+    remote = attr.ib()
     img_dir = attr.ib()
 
     def __attrs_post_init__(self):
@@ -39,6 +40,8 @@ class Mirror():
 
     @property
     def servername(self):
+        if self.remote:
+            return self.remote
         match = re.search(r'https://([\w\.]*):?\d*', self.url)
         if match:
             return match.group(1)
@@ -69,6 +72,7 @@ class MirrorManager():
                     mirror['user'],
                     mirror['key_path'],
                     mirror['url'],
+                    mirror.get('remote'),
                     cls.img_dir
                 )
             logger.info('Mirror list updated')


### PR DESCRIPTION
Url config is broken because the parser is not considering `-`. 

As I think it does not make sense use complete url, I have add a new option remote to replace it.